### PR TITLE
Doc tweaks and typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PMC-VVV
 
-Configuration repo for PMC's use of VVV
+Configuration repo for PMC's use of VVV.
+
+VVV is an open source local development environment designed for WordPress developers, and is used for both working on WordPress sites and contributing to WordPress Core.
 
 This repo holds both a complete `config.yml` for VVV as well as the tools to
 update it as the configuration changes or sites are added.
@@ -8,7 +10,7 @@ update it as the configuration changes or sites are added.
 ## Prerequisites
 
 1. [Virtualbox](https://www.virtualbox.org/) and [Vagrant](https://www.vagrantup.com/)
-1. A checkout of [VVV](https://github.com/Varying-Vagrant-Vagrants/vvv)
+1. A checkout (i.e. clone) of the [VVV](https://github.com/Varying-Vagrant-Vagrants/vvv) repo
 1. SSH key forwarding via `ssh-agent` (see [below](#ssh-agent))
 
 ### `ssh-agent`
@@ -29,11 +31,11 @@ To do so:
 
 ## Using with VVV
 
-1. Install Vagrant plugins:
+1. Install Vagrant plugins (run this command from inside directory of the VVV clone from the #2 prerequisite):
    ```bash
    $ vagrant plugin install vagrant-hostsupdater vagrant-disksize vagrant-scp
    ```
-1. Copy `config.yml` to the `config` directory in your VVV install, typically
+1. Copy `config.yml` from this repo to the `config` directory in your VVV install, typically
    `~/vvv/config/`.
 1. Enable the site or sites you need by changing the site's `skip_provisioning`
    value to `false`. By default, no sites are provisioned, allowing each
@@ -49,6 +51,10 @@ To do so:
    the end of the configuration.
 1. Adjust the `vm_config` and `disksize` values if needed, such as when working
    with databases from some of our larger sites.
+1. Provision Vagrant (i.e. install dependencies for the first time) as usual:
+   ```bash
+      $ vagrant up --provision
+   ```
 
 Note that at any time in the future, you can change which sites are provisioned
 and run `vagrant provision` to create the new sites. VVV does not remove sites

--- a/README.md
+++ b/README.md
@@ -30,37 +30,37 @@ To do so:
 ## Using with VVV
 
 1. Install Vagrant plugins:
-   ```bash 
-   $ vagrant plugin install vagrant-hostupdater vagrant-disksize vagrant-scp
+   ```bash
+   $ vagrant plugin install vagrant-hostsupdater vagrant-disksize vagrant-scp
    ```
 1. Copy `config.yml` to the `config` directory in your VVV install, typically
    `~/vvv/config/`.
 1. Enable the site or sites you need by changing the site's `skip_provisioning`
-   value to `false`. By default, no sites are provisioned, allowing each 
-   developer to install only the sites they work on. Each site takes 
+   value to `false`. By default, no sites are provisioned, allowing each
+   developer to install only the sites they work on. Each site takes
    approximately 3.5 minutes to provision.
-   
-   1. Enable the `wordpress-trunk` site if you plan to run PHPUnit in VVV 
+
+   1. Enable the `wordpress-trunk` site if you plan to run PHPUnit in VVV
       instead of Docker.
-      
+
       **Note** that it requires manual configuration, such as installing our
-      shared plugins and any theme code to be tested. 
-1. If desired, add optional PMC utilities to the `utilities.pmc` array towards 
+      shared plugins and any theme code to be tested.
+1. If desired, add optional PMC utilities to the `utilities.pmc` array towards
    the end of the configuration.
-1. Adjust the `vm_config` and `disksize` values if needed, such as when working 
+1. Adjust the `vm_config` and `disksize` values if needed, such as when working
    with databases from some of our larger sites.
-   
+
 Note that at any time in the future, you can change which sites are provisioned
 and run `vagrant provision` to create the new sites. VVV does not remove sites
-that were previously provisioned, but it does remove the site's hosts entry, 
+that were previously provisioned, but it does remove the site's hosts entry,
 restricting access to only WP-CLI.
 
 ## HTTPS (SSL)
 
 To match production, all local environments are configured to use HTTPS URLs.
-Browsers will display certificate errors after you first provision VVV. 
+Browsers will display certificate errors after you first provision VVV.
 
-To fix these errors, see VVV's instructions at 
+To fix these errors, see VVV's instructions at
 https://varyingvagrantvagrants.org/docs/en-US/references/https/trusting-ca/.
 
 ## Default WordPress Login
@@ -85,13 +85,13 @@ Flush the rewrite rules in `wp-admin` under VIP > Dashboard > Rewrite Rules.
 
 ### I'm already using `pmc-vvv`. What's next?
 
-There are several options for adopting the latest VVV configuration. 
+There are several options for adopting the latest VVV configuration.
 
-1. Start fresh: 
-   1. Run `vagrant destroy` 
+1. Start fresh:
+   1. Run `vagrant destroy`
    1. Delete the VVV directory
    1. Check out VVV, drop in the new configuration, and provision
-1. Migrate to a fresh instance: 
+1. Migrate to a fresh instance:
    1. Run `vagrant destroy`
    1. Copy the database backups to a safe location (from `database/sql/backups`)
    1. Delete the VVV install and start anew
@@ -102,15 +102,15 @@ There are several options for adopting the latest VVV configuration.
       1. Run `wp search-replace [OLD URL] [NEW URL]`
       1. Flush the cache: `wp cache flush`
 1. Set up a new VVV instance alongside your existing one. As long as both aren't
-   running at the same time, they can coexist. 
+   running at the same time, they can coexist.
 1. Retain sites set up using `build-me-vvv.sh` (**NOT RECOMMENDED**):
    1. Modify the generated config so that the site slug and host matches what's
       currently in use.
-   1. Set the site to use the 
+   1. Set the site to use the
       [default VVV provisioner](https://github.com/Varying-Vagrant-Vagrants/custom-site-template)
       rather than our custom one, pulling from the `master` branch
    1. Run `vagrant destroy` and `vagrant provision`
-      
+
       The existing sites will remain, including the unused `wpcom.test` network,
       and you'll need to reconcile your updates with any future changes to the
       generated config, but this will retain all of your existing sites in case
@@ -123,27 +123,27 @@ Error: `git@github.com: Permission denied (publickey).fatal: Could not read from
 Fix: Add key to ssh-agent using: `ssh-add -K [PATH_TO_PRIVATE_KEY]`
 ### 2/11/2020
 
-Error: `Failed to start The PHP 7.2 FastCGI Process Manager.` during 
+Error: `Failed to start The PHP 7.2 FastCGI Process Manager.` during
 provisioning and 502 Bad Gateway error in HTTP response.
 
-Fix: Update VVV to latest version and `vagrant reload --provision`. See 
-[this Github issue](https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2061#issuecomment-583557584) 
+Fix: Update VVV to latest version and `vagrant reload --provision`. See
+[this Github issue](https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2061#issuecomment-583557584)
 for further troubleshooting.
 
 ## Related repos:
 
 This configuration builds on two additional repositories, in keeping with the
-patterns established by VVV. This should lower the maintenance burden by 
+patterns established by VVV. This should lower the maintenance burden by
 leveraging as much of the open-source project as possible.
 
 1. Utilities: https://github.com/penske-media-corp/pmc-vvv-utilities
-   
+
    This repo contains all PMC modifications to VVV, such as installing our PHPCS
    standards and creating a local cache of shared code used during site
    provisioning.
 1. Provisioners: https://github.com/penske-media-corp/pmc-vvv-site-provisioners
 
-   This repo contains PMC's extensions of VVV's site provisioners. These 
+   This repo contains PMC's extensions of VVV's site provisioners. These
    leverage features added by our custom utilities and take the place of the
    build script that previously handled tasks like installing `pmc-plugins` and
    a site's theme(s).


### PR DESCRIPTION
Add some more explicit instructions for cloning VVV and running commands – could be confusing for those who have not worked with VVV before.

I have something in my editor that removes trailing spaces on save – that's causing a bigger diff. LMK if that's an issue!