### PR TITLE
Remove utilities breaking during provisioning

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -551,9 +551,7 @@ utilities:
     - phpmyadmin
     - memcached-admin
     - opcache-status
-    - tideways
     - webgrind
-    - mongodb
     - php73
     - php74
   pmc:


### PR DESCRIPTION
[See the conversation in slack](https://penskemediacorp.slack.com/archives/C0AN3PRLP/p1630004346007700) - these were breaking because of an issue with a missing release file in Mongo.