### PR TITLE
Update Misc. Issues with "unsafe repo" note

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,27 +255,10 @@ There are several options for adopting the latest VVV configuration.
 
 Error: Provisioning fails with the message `fatal: unsafe repository ('/srv/provision/utilities/pmc' is owned by someone else)`. It is not resolved by re-adding the SSH key nor by running the suggested command `git config --global --add safe.directory`.
 
-Fix: Find provision.sh in your VVV directory, e.g. VVV/provision/provision.sh. Before the conditional around like 36, add the following:
+Fix: Run the following
 
 ```
-git config --global --add safe.directory /srv/provision/utilities/pmc
-git config --global --add safe.directory /srv/provision/utilities/core
-git config --global --add safe.directory /srv/provision/extensions/pmc
-git config --global --add safe.directory /srv/provision/extensions/core
-git config --global --add safe.directory /srv/www/wordpress-trunk
-```
-
-Then, for each site enabled in config.yml, add the following:
-
-```
-git config --global --add safe.directory /srv/www/deadline-com
-git config --global --add safe.directory /srv/www/indiewire-com
-git config --global --add safe.directory /srv/www/robbreport-com
-git config --global --add safe.directory /srv/www/rollingstone-2022-com
-git config --global --add safe.directory /srv/www/sportico-com
-git config --global --add safe.directory /srv/www/rollingstone-com
-git config --global --add safe.directory /srv/www/variety-com
-git config --global --add safe.directory /srv/www/vibe-com
+git config --global --add safe.directory *
 ```
 
 Note: You might need to update Git to the latest version (at the time of this writing, version 2.36.0 works). The steps for updating Git will vary depending on your operating system, so search for instructions as needed. [Here is a Mac-specific guide](https://git-scm.com/download/mac) maintained by Git community members.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ NOTE, Ideally, we could provision wordpress-trunk into VVV via [custom-site-temp
     # If not in VM...
     $ vagrant ssh
     ```
-    
+
     In VM...
     ```bash
     You can add these variables to your bash, but make sure they are at the bottom of ~/.bash_profile as not to conflict with vvv's settings.
@@ -250,6 +250,36 @@ There are several options for adopting the latest VVV configuration.
       you have something set up that you cannot part with.
 
 ## Miscellaneous Issues
+
+### 04/26/2022
+
+Error: Provisioning fails with the message `fatal: unsafe repository ('/srv/provision/utilities/pmc' is owned by someone else)`. It is not resolved by re-adding the SSH key nor by running the suggested command `git config --global --add safe.directory`.
+
+Fix: Find provision.sh in your VVV directory, e.g. VVV/provision/provision.sh. Before the conditional around like 36, add the following:
+
+```
+git config --global --add safe.directory /srv/provision/utilities/pmc
+git config --global --add safe.directory /srv/provision/utilities/core
+git config --global --add safe.directory /srv/provision/extensions/pmc
+git config --global --add safe.directory /srv/provision/extensions/core
+git config --global --add safe.directory /srv/www/wordpress-trunk
+```
+
+Then, for each site enabled in config.yml, add the following:
+
+```
+git config --global --add safe.directory /srv/www/deadline-com
+git config --global --add safe.directory /srv/www/indiewire-com
+git config --global --add safe.directory /srv/www/robbreport-com
+git config --global --add safe.directory /srv/www/rollingstone-2022-com
+git config --global --add safe.directory /srv/www/sportico-com
+git config --global --add safe.directory /srv/www/rollingstone-com
+git config --global --add safe.directory /srv/www/variety-com
+git config --global --add safe.directory /srv/www/vibe-com
+```
+
+Note: You might need to update Git to the latest version (at the time of this writing, version 2.36.0 works). The steps for updating Git will vary depending on your operating system, so search for instructions as needed. [Here is a Mac-specific guide](https://git-scm.com/download/mac) maintained by Git community members.
+
 ### 04/12/2022
 Error: Unable to launch xdebug with Parallels.
 

--- a/README.md
+++ b/README.md
@@ -255,13 +255,13 @@ There are several options for adopting the latest VVV configuration.
 
 Error: Provisioning fails with the message `fatal: unsafe repository ('/srv/provision/utilities/pmc' is owned by someone else)`. It is not resolved by re-adding the SSH key nor by running the suggested command `git config --global --add safe.directory`.
 
-Fix: Run the following
+Fix: Confirm you are using Git v2.35.3+ and run the following command before running the command to provision:
 
 ```
 git config --global --add safe.directory *
 ```
 
-Note: You might need to update Git to the latest version (at the time of this writing, version 2.36.0 works). The steps for updating Git will vary depending on your operating system, so search for instructions as needed. [Here is a Mac-specific guide](https://git-scm.com/download/mac) maintained by Git community members.
+Note: You might need to update Git to the latest version. The steps for updating Git will vary depending on your operating system, so search for instructions as needed. [Here is a Mac-specific guide](https://git-scm.com/download/mac) maintained by Git community members.
 
 ### 04/12/2022
 Error: Unable to launch xdebug with Parallels.


### PR DESCRIPTION
Add note and fix to the Miscellaneous issues section about a fatal error: `fatal: unsafe repository ('/srv/provision/utilities/pmc' is owned by someone else)` during provisioning.