### PR TITLE
Php8 info update

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -13,7 +13,7 @@ sites:
       admin_user: pmcdev
       admin_password: pmcdev
       pmc:
-        theme_repo: git@bitbucket.org:penskemediacorp/pmc-artnews-2019.git
+        theme_repo: git@github.com:penske-media-corp/pmc-artnews-2019.git
         theme_slug: ""
         parent_theme_slug: pmc-core-v2
         theme_dir_uses_vip: true
@@ -139,7 +139,7 @@ sites:
       admin_user: pmcdev
       admin_password: pmcdev
       pmc:
-        theme_repo: git@bitbucket.org:penskemediacorp/pmc-summits-wwd.git
+        theme_repo: git@github.com:penske-media-corp/pmc-summits-wwd.git
         theme_slug: ""
         parent_theme_slug: pmc-summits
         theme_dir_uses_vip: false
@@ -157,7 +157,7 @@ sites:
       admin_user: pmcdev
       admin_password: pmcdev
       pmc:
-        theme_repo: git@bitbucket.org:penskemediacorp/pmc-footwearnews-2018.git
+        theme_repo: git@github.com:penske-media-corp/pmc-footwearnews-2018.git
         theme_slug: ""
         parent_theme_slug: pmc-core-v2
         theme_dir_uses_vip: false
@@ -391,7 +391,7 @@ sites:
       admin_user: pmcdev
       admin_password: pmcdev
       pmc:
-        theme_repo: git@bitbucket.org:penskemediacorp/pmc-sportico-2020.git
+        theme_repo: git@github.com:penske-media-corp/pmc-sportico-2020.git
         theme_slug: ""
         parent_theme_slug: pmc-core-v2
         theme_dir_uses_vip: true

--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ sites:
     branch: main
     hosts:
       - artnews-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://artnews.com
       site_title: Artnews (LOCAL)
@@ -24,7 +24,7 @@ sites:
     branch: main
     hosts:
       - bgr-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://bgr.com
       site_title: BGR (LOCAL)
@@ -42,7 +42,7 @@ sites:
     branch: main
     hosts:
       - billboard-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://billboard.com
       site_title: Billboard (LOCAL)
@@ -60,7 +60,7 @@ sites:
     branch: main
     hosts:
       - blogher-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://blogher.com
       site_title: BlogHer (LOCAL)
@@ -78,7 +78,7 @@ sites:
     branch: main
     hosts:
       - deadline-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://deadline.com
       site_title: Deadline (LOCAL)
@@ -96,7 +96,7 @@ sites:
     branch: main
     hosts:
       - dirt-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://dirt.com
       site_title: Dirt (LOCAL)
@@ -114,7 +114,7 @@ sites:
     branch: main
     hosts:
       - engineering-pmc-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://engineering.pmc.com
       site_title: PMC Engineering (LOCAL)
@@ -132,7 +132,7 @@ sites:
     branch: main
     hosts:
       - events-fairchildlive-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://events.fairchildlive.com
       site_title: Fairchild Live Events (LOCAL)
@@ -150,7 +150,7 @@ sites:
     branch: main
     hosts:
       - footwearnews-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://footwearnews.com
       site_title: Footwearnews (LOCAL)
@@ -168,7 +168,7 @@ sites:
     branch: master
     hosts:
       - goldderby-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://goldderby.com
       site_title: Gold Derby (LOCAL)
@@ -186,7 +186,7 @@ sites:
     branch: main
     hosts:
       - hollywoodreporter-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://hollywoodreporter.com
       site_title: Hollywoodreporter (LOCAL)
@@ -204,7 +204,7 @@ sites:
     branch: main
     hosts:
       - indiewire-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://indiewire.com
       site_title: Indiewire (LOCAL)
@@ -240,7 +240,7 @@ sites:
     branch: main
     hosts:
       - pmc-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://pmc.com
       site_title: PMC Corp (LOCAL)
@@ -258,7 +258,7 @@ sites:
     branch: main
     hosts:
       - robbreport-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://robbreport.com
       site_title: Robb Report (LOCAL)
@@ -276,7 +276,7 @@ sites:
     branch: main
     hosts:
       - robbreport-uk-co.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://robbreport.uk.co
       site_title: Robb Report UK (LOCAL)
@@ -294,27 +294,9 @@ sites:
     branch: main
     hosts:
       - rollingstone-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://rollingstone.com
-      site_title: Rolling Stone (LOCAL)
-      admin_user: pmcdev
-      admin_password: pmcdev
-      pmc:
-        theme_repo: git@bitbucket.org:penskemediacorp/pmc-rollingstone-2018.git
-        theme_slug: ""
-        parent_theme_slug: pmc-core-v2
-        theme_dir_uses_vip: true
-  rollingstone-2022-com:
-    skip_provisioning: true
-    description: rollingstone-2022.com
-    repo: git@github.com:penske-media-corp/pmc-vvv-site-provisioners.git
-    branch: main
-    hosts:
-      - rollingstone-2022-com.test
-    nginx_upstream: php74
-    custom:
-      live_url: https://rollingstone-2022.com
       site_title: Rolling Stone (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
@@ -330,7 +312,7 @@ sites:
     branch: main
     hosts:
       - rr1-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://rr1.com
       site_title: RR1 (LOCAL)
@@ -348,7 +330,7 @@ sites:
     branch: main
     hosts:
       - sales-pmcdev-io.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://sales.pmcdev.io
       site_title: Sales Microsites (LOCAL)
@@ -366,7 +348,7 @@ sites:
     branch: main
     hosts:
       - sheknows-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://sheknows.com
       site_title: Sheknows (LOCAL)
@@ -384,7 +366,7 @@ sites:
     branch: main
     hosts:
       - soaps-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://soaps.com
       site_title: Soaps (LOCAL)
@@ -402,7 +384,7 @@ sites:
     branch: main
     hosts:
       - sportico-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://sportico.com
       site_title: Sportico (LOCAL)
@@ -416,31 +398,13 @@ sites:
   sourcingjournal-com:
     skip_provisioning: true
     description: sourcingjournal.com
-    repo: git@github.com:Varying-Vagrant-Vagrants/custom-site-template.git
-    branch: master
-    hosts:
-      - sourcingjournal-com.test
-    nginx_upstream: php73
-    custom:
-      live_url: https://sourcingjournal.com
-      site_title: Sourcing Journal (LOCAL)
-      admin_user: pmcdev
-      admin_password: pmcdev
-      pmc:
-        theme_repo: git@bitbucket.org:penskemediacorp/pmc-sourcingjournal-2018.git
-        theme_slug: ""
-        parent_theme_slug: pmc-core-v2
-        theme_dir_uses_vip: true
-  sourcingjournal-2021-com:
-    skip_provisioning: true
-    description: sourcingjournal-2021.com
     repo: git@github.com:penske-media-corp/pmc-vvv-site-provisioners.git
     branch: main
     hosts:
-      - sourcingjournal-2021-com.test
-    nginx_upstream: php74
+      - sourcingjournal-com.test
+    nginx_upstream: php80
     custom:
-      live_url: https://sourcingjournal-2021.com
+      live_url: https://sourcingjournal.com
       site_title: Sourcing Journal (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
@@ -456,27 +420,9 @@ sites:
     branch: main
     hosts:
       - spy-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://spy.com
-      site_title: Spy (LOCAL)
-      admin_user: pmcdev
-      admin_password: pmcdev
-      pmc:
-        theme_repo: git@bitbucket.org:penskemediacorp/pmc-spy.git
-        theme_slug: ""
-        parent_theme_slug: ""
-        theme_dir_uses_vip: false
-  spy-2022-com:
-    skip_provisioning: true
-    description: spy-2022.com
-    repo: git@github.com:penske-media-corp/pmc-vvv-site-provisioners.git
-    branch: main
-    hosts:
-      - spy-2022-com.test
-    nginx_upstream: php74
-    custom:
-      live_url: https://spy-2022.com
       site_title: Spy (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
@@ -492,7 +438,7 @@ sites:
     branch: main
     hosts:
       - stylecaster-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://stylecaster.com
       site_title: Stylecaster (LOCAL)
@@ -510,7 +456,7 @@ sites:
     branch: main
     hosts:
       - tvline-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://tvline.com
       site_title: TV Line (LOCAL)
@@ -528,7 +474,7 @@ sites:
     branch: main
     hosts:
       - variety-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://variety.com
       site_title: Variety (LOCAL)
@@ -546,7 +492,7 @@ sites:
     branch: main
     hosts:
       - vibe-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://vibe.com
       site_title: Vibe (LOCAL)
@@ -564,28 +510,10 @@ sites:
     branch: main
     hosts:
       - wwd-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://wwd.com
       site_title: WWD (LOCAL)
-      admin_user: pmcdev
-      admin_password: pmcdev
-      pmc:
-        theme_repo: git@bitbucket.org:penskemediacorp/pmc-wwd-2016.git
-        theme_slug: ""
-        parent_theme_slug: ""
-        theme_dir_uses_vip: false
-  wwd-2021-com:
-    skip_provisioning: true
-    description: wwd-2021.com
-    repo: git@github.com:penske-media-corp/pmc-vvv-site-provisioners.git
-    branch: main
-    hosts:
-      - wwd-2021-com.test
-    nginx_upstream: php74
-    custom:
-      live_url: https://wwd-2021.com
-      site_title: WWD 2021 (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
       pmc:
@@ -600,7 +528,7 @@ sites:
     branch: main
     hosts:
       - studios-wwd-com.test
-    nginx_upstream: php74
+    nginx_upstream: php80
     custom:
       live_url: https://studios.wwd.com
       site_title: WWD Studios (LOCAL)
@@ -624,9 +552,8 @@ utilities:
     - memcached-admin
     - opcache-status
     - webgrind
-    - php73
-    - php74
     - php80
+    - php81
   pmc:
     - coretech
     - http-concat

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -111,3 +111,35 @@ To confirm which PHP version is used by WP-CLI, run:
 
 Confirm that the `PHP version` and `php.ini used` lines reference the 
 expected version.
+
+
+### PHPUNIT with PHP 8:
+
+The steps to install are similar to the [existing docs](../docs/unit-tests.md). Until we switch completely to PHP8, I recommend making a parallel installation. PHP8 allows/requires us to use PHPUnit 9, which requires us to use WordPress 6 test suite and add yoast/phpunit-polyfills  
+
+```bash
+   * sudo mkdir -p /usr/share/php/phpunit9
+   * cd /usr/share/php/phpunit9
+   * sudo php8.0 composer require --dev phpunit/phpunit ^9 --update-with-all-dependencies
+   * sudo ln -sf /usr/share/php/phpunit9/vendor/bin/phpunit /usr/bin/phpunit9
+   * cd
+   * git clone --depth 1 --branch 6.0.1 git@github.com:WordPress/wordpress-develop.git  wordpress-6
+   * cp -r wordpress-6/tests /srv/www/variety-com/public_html/ // This should be the site you're going to be testing against
+```
+
+CD into the pmc-plugins directory of the site you're migrating.
+```bash
+   * php8.0 /usr/local/bin/composer require --dev yoast/phpunit-polyfills
+```
+
+In the unit tests bootstrap file, add ```require_once '../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';``` pointing at the vendor directory where you installed yoast/phpunit-polyfills
+
+You will need to export the PMC_PHPUNIT_BOOTSTRAP and the WP_TESTS_DIR. 
+
+CD into the directory you need to run tests in and run: 
+```bash
+phpunit9 --migrate-configuration
+```
+
+You will likely run into many new Fatal Errors that need fixing before you're able to successfully run a test.
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -106,6 +106,8 @@ expected version.
 
 ### PHPUNIT with PHP 8:
 
+First, make sure you have php 8 installed ([see above in the FAQ](#if-your-configyml-does-not-include-the-desired-php-version-in-the-utilitiescore-section)).
+
 The steps to install are similar to the [existing docs](../docs/unit-tests.md). Until we switch completely to PHP8, I recommend making a parallel installation. PHP8 requires us to use PHPUnit 9, which requires us to use the WordPress 6 test suite and add the yoast/phpunit-polyfills  
 
 Any time you are using a specific version of php to run a command, you need the full path, i.e. `php8.0 /usr/local/bin/composer ...` instead of just `php8.0 composer ...`.
@@ -120,12 +122,12 @@ Any time you are using a specific version of php to run a command, you need the 
    * cp -r wordpress-6/tests /srv/www/variety-com/public_html/ // This should be the site you're going to be testing against
 ```
 
-CD into the pmc-plugins/pmc-unit-test directory of the site you're migrating.
+CD into the pmc-plugins directory of the site you're migrating.
 ```bash
    * php8.0 /usr/local/bin/composer require --dev yoast/phpunit-polyfills
 ```
 
-In the unit tests bootstrap file, add ```require_once './vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';``` pointing at the vendor directory where you installed yoast/phpunit-polyfills
+In the unit tests bootstrap file (`pmc-unit-test/bootstrap.php`), add ```require_once '/FULL/PATH/TO/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';``` pointing at the vendor directory where you installed yoast/phpunit-polyfills. (You can install the polyfills package in pmc-unit-test, but composer doesn't like the composer.json in that directory, so you would need to modify it first.)
 
 You will need to export the PMC_PHPUNIT_BOOTSTRAP and the WP_TESTS_DIR. 
 
@@ -139,3 +141,18 @@ You will be prompted to migrate the phpunit.xml, but hold off until we've migrat
 
 You will likely run into many new Fatal Errors that need fixing before you're able to successfully run a test until we have merged in a bunch of phpunit tests in pmc-plugins.
 
+Until the [php8 compatibility PRs](https://github.com/penske-media-corp/pmc-unit-test/pulls) are merged in the pmc-unit-test package and updated in pmc-plugins/pmc-unit-test, you need to update them yourself. I find the easiest was it to pull down the pmc-unit-test git repo and merge without committing, then copying these files :
+
+  * pmc-unit-test/autoload.php
+  * pmc-unit-test/src/classes/bootstrap.php
+  * pmc-unit-test/src/mocks/factory.php
+  * pmc-unit-test/src/traits/base.php
+
+into:
+
+  * pmc-plugins/pmc-unit-test/vendor/pmc/unit-test/autoload.php
+  * pmc-plugins/pmc-unit-test/vendor/pmc/unit-test/src/classes/bootstrap.php
+  * pmc-plugins/pmc-unit-test/vendor/pmc/unit-test/src/mocks/factory.php
+  * pmc-plugins/pmc-unit-test/vendor/pmc/unit-test/src/traits/base.php
+
+  

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -90,9 +90,9 @@ To run WP-CLI with a different PHP version, such as PHP 8.0:
 ```
 
 The three available PHP versions, and their paths, are:
-* 7.3: `/usr/bin/php7.3`
 * 7.4: `/usr/bin/php7.4`
 * 8.0: `/usr/bin/php8.0`
+* 8.1: `/usr/bin/php8.1`
 
 To confirm which PHP version is used by WP-CLI, run:
 
@@ -112,27 +112,28 @@ The steps to install are similar to the [existing docs](../docs/unit-tests.md). 
 
 Any time you are using a specific version of php to run a command, you need the full path, i.e. `php8.0 /usr/local/bin/composer ...` instead of just `php8.0 composer ...`.
 
+
 ```bash
-   * sudo mkdir -p /usr/share/php/phpunit9
-   * cd /usr/share/php/phpunit9
-   * sudo php8.0 /usr/local/bin/composer require --dev phpunit/phpunit ^9 --update-with-all-dependencies
-   * sudo ln -sf /usr/share/php/phpunit9/vendor/bin/phpunit /usr/bin/phpunit9
-   * cd
-   * git clone --depth 1 --branch 6.0.1 git@github.com:WordPress/wordpress-develop.git  wordpress-6
-   * cp -r wordpress-6/tests /srv/www/variety-com/public_html/ // This should be the site you're going to be testing against
+sudo mkdir -p /usr/share/php/phpunit9
+cd /usr/share/php/phpunit9
+sudo php8.0 /usr/local/bin/composer require --dev phpunit/phpunit ^9 --update-with-all-dependencies
+sudo ln -sf /usr/share/php/phpunit9/vendor/bin/phpunit /usr/bin/phpunit9
+cd
+git clone --depth 1 --branch 6.0.1 git@github.com:WordPress/wordpress-develop.git  wordpress-6
+cp -r wordpress-6/tests /srv/www/variety-com/public_html/  
 ```
 
-CD into the pmc-plugins directory of the site you're migrating.
+Change into the pmc-plugins/pmc-unit-test directory of the site you're migrating.
 ```bash
-   * php8.0 /usr/local/bin/composer require --dev yoast/phpunit-polyfills
+cd pmc-plugins/pmc-unit-test
+php8.0 /usr/local/bin/composer require --dev yoast/phpunit-polyfills
 ```
-
-In the unit tests bootstrap file (`pmc-unit-test/bootstrap.php`), add ```require_once '/FULL/PATH/TO/vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';``` pointing at the vendor directory where you installed yoast/phpunit-polyfills. (You can install the polyfills package in pmc-unit-test, but composer doesn't like the composer.json in that directory, so you would need to modify it first.)
 
 You will need to export the PMC_PHPUNIT_BOOTSTRAP and the WP_TESTS_DIR. 
 
-CD into the pmc-plugins directory and run tests by passing the necessary configuration file: 
+Change into the pmc-plugins directory and run tests by passing the necessary configuration file. For instance, if you wanted to run the tests for pmc-global-functions: 
 ```bash
+cd ../pmc-plugins
 php8.0  /usr/bin/phpunit9 --configuration=pmc-global-functions
 ```
 Don't forget the php8.0 executable and the full path to phpunit9. 
@@ -140,19 +141,3 @@ Don't forget the php8.0 executable and the full path to phpunit9.
 You will be prompted to migrate the phpunit.xml, but hold off until we've migrated everything to php8 environments.
 
 You will likely run into many new Fatal Errors that need fixing before you're able to successfully run a test until we have merged in a bunch of phpunit tests in pmc-plugins.
-
-Until the [php8 compatibility PRs](https://github.com/penske-media-corp/pmc-unit-test/pulls) are merged in the pmc-unit-test package and updated in pmc-plugins/pmc-unit-test, you need to update them yourself. I find the easiest was it to pull down the pmc-unit-test git repo and merge without committing, then copying these files :
-
-  * pmc-unit-test/autoload.php
-  * pmc-unit-test/src/classes/bootstrap.php
-  * pmc-unit-test/src/mocks/factory.php
-  * pmc-unit-test/src/traits/base.php
-
-into:
-
-  * pmc-plugins/pmc-unit-test/vendor/pmc/unit-test/autoload.php
-  * pmc-plugins/pmc-unit-test/vendor/pmc/unit-test/src/classes/bootstrap.php
-  * pmc-plugins/pmc-unit-test/vendor/pmc/unit-test/src/mocks/factory.php
-  * pmc-plugins/pmc-unit-test/vendor/pmc/unit-test/src/traits/base.php
-
-  

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -49,31 +49,25 @@ There are several options for adopting the latest VVV configuration.
 
 ### If your `config.yml` does not include the desired PHP version in the `utilities.core` section:
 
-1. Add it there, eg `php80` or `php81`.
+1. Add it there, e.g. `php80` or `php81`.
 1. For sites you wish to switch to the new version, update the 
-   `nginx_upstream` in the site's configuration to match the desired version,
-   eg `php80`.
+   `nginx_upstream` in the site's configuration to match the desired version, e.g. `php80`.
 1. Run `vagrant provision`.
 
 ### If you've already provisioned the new PHP version:
 
 #### Via `vagrant provision`:
 
-1. Update the `nginx_upstream` in the site's section of `config.yml` to match 
-   the desired version, eg `php80`.
+1. Update the `nginx_upstream` in the site's section of `config.yml` to match  the desired version, e.g. `php80`.
 1. Run `vagrant provision`.
 
 #### Without re-provisioning:
 
 1. `vagrant ssh` and change to the `/etc/nginx/custom-sites` directory.
-1. Run `ls -la` and find the filename of the site you wish to update. It 
-   will be in the format of `vvv-[SITE_SLUG]-[HASH].conf`.
-1. Use the `sudo` command to edit the file identified in the previous step, 
-   eg `sudo vim` or `sudo nano`.
-1. Find the line that's preceded by the comment `# This is needed to set the 
-   PHP being used`.
-1. At the end of the following line, change the specified PHP version to the 
-   desired version.
+1. Run `ls -la` and find the filename of the site you wish to update. It  will be in the format of `vvv-[SITE_SLUG]-[HASH].conf`.
+1. Use the `sudo` command to edit the file identified in the previous step, e.g. `sudo vim` or `sudo nano`.
+1. Find the line that's preceded by the comment `# This is needed to set the PHP being used`.
+1. At the end of the following line, change the specified PHP version to the  desired version.
 
    For example, if the line was:
 
@@ -87,10 +81,7 @@ There are several options for adopting the latest VVV configuration.
 
 ### Using a different PHP version with WP-CLI:
 
-Note that switching an individual site's PHP version applies only to the web 
-server, but does not affect the PHP version used by WP-CLI. Additionally, 
-the `WP_CLI_PHP` environment variable has no effect on the PHP version used 
-by the copy of WP-CLI installed in the VM.
+Note that switching an individual site's PHP version applies only to the web server, but does not affect the PHP version used by WP-CLI. Additionally, the `WP_CLI_PHP` environment variable has no effect on the PHP version used by the copy of WP-CLI installed in the VM.
 
 To run WP-CLI with a different PHP version, such as PHP 8.0:
 
@@ -115,7 +106,7 @@ expected version.
 
 ### PHPUNIT with PHP 8:
 
-The steps to install are similar to the [existing docs](../docs/unit-tests.md). Until we switch completely to PHP8, I recommend making a parallel installation. PHP8 allows/requires us to use PHPUnit 9, which requires us to use WordPress 6 test suite and add yoast/phpunit-polyfills  
+The steps to install are similar to the [existing docs](../docs/unit-tests.md). Until we switch completely to PHP8, I recommend making a parallel installation. PHP8 requires us to use PHPUnit 9, which requires us to use the WordPress 6 test suite and add the yoast/phpunit-polyfills  
 
 ```bash
    * sudo mkdir -p /usr/share/php/phpunit9
@@ -127,19 +118,22 @@ The steps to install are similar to the [existing docs](../docs/unit-tests.md). 
    * cp -r wordpress-6/tests /srv/www/variety-com/public_html/ // This should be the site you're going to be testing against
 ```
 
-CD into the pmc-plugins directory of the site you're migrating.
+CD into the pmc-plugins/pmc-unit-test directory of the site you're migrating.
 ```bash
    * php8.0 /usr/local/bin/composer require --dev yoast/phpunit-polyfills
 ```
 
-In the unit tests bootstrap file, add ```require_once '../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';``` pointing at the vendor directory where you installed yoast/phpunit-polyfills
+In the unit tests bootstrap file, add ```require_once './vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';``` pointing at the vendor directory where you installed yoast/phpunit-polyfills
 
 You will need to export the PMC_PHPUNIT_BOOTSTRAP and the WP_TESTS_DIR. 
 
-CD into the directory you need to run tests in and run: 
+CD into the pmc-plugins directory and run tests by passing the necessary configuration file: 
 ```bash
-phpunit9 --migrate-configuration
+php8.0  /usr/bin/phpunit9 --configuration=pmc-global-functions
 ```
+Don't forget the php8.0 executable and the full path to phpunit9. 
 
-You will likely run into many new Fatal Errors that need fixing before you're able to successfully run a test.
+You will be prompted to migrate the phpunit.xml, but hold off until we've migrated everything to php8 environments.
+
+You will likely run into many new Fatal Errors that need fixing before you're able to successfully run a test until we have merged in a bunch of phpunit tests in pmc-plugins.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -108,10 +108,12 @@ expected version.
 
 The steps to install are similar to the [existing docs](../docs/unit-tests.md). Until we switch completely to PHP8, I recommend making a parallel installation. PHP8 requires us to use PHPUnit 9, which requires us to use the WordPress 6 test suite and add the yoast/phpunit-polyfills  
 
+Any time you are using a specific version of php to run a command, you need the full path, i.e. `php8.0 /usr/local/bin/composer ...` instead of just `php8.0 composer ...`.
+
 ```bash
    * sudo mkdir -p /usr/share/php/phpunit9
    * cd /usr/share/php/phpunit9
-   * sudo php8.0 composer require --dev phpunit/phpunit ^9 --update-with-all-dependencies
+   * sudo php8.0 /usr/local/bin/composer require --dev phpunit/phpunit ^9 --update-with-all-dependencies
    * sudo ln -sf /usr/share/php/phpunit9/vendor/bin/phpunit /usr/bin/phpunit9
    * cd
    * git clone --depth 1 --branch 6.0.1 git@github.com:WordPress/wordpress-develop.git  wordpress-6

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,7 +50,7 @@ There are several options for adopting the latest VVV configuration.
 ### If your `config.yml` does not include the desired PHP version in the `utilities.core` section:
 
 1. Add it there, e.g. `php80` or `php81`.
-1. For sites you wish to switch to the new version, update the 
+1. For sites you wish to switch to the new version, update the
    `nginx_upstream` in the site's configuration to match the desired version, e.g. `php80`.
 1. Run `vagrant provision`.
 
@@ -71,11 +71,11 @@ There are several options for adopting the latest VVV configuration.
 
    For example, if the line was:
 
-   ```set          $upstream php74;``` 
+   ```set          $upstream php74;```
 
    And you want to set the site to PHP 8.0, change it to:
 
-   ```set          $upstream php80;``` 
+   ```set          $upstream php80;```
 1. Save the file and exit the editor.
 1. Restart nginx by running `sudo /etc/init.d/nginx restart`.
 
@@ -89,8 +89,7 @@ To run WP-CLI with a different PHP version, such as PHP 8.0:
 /usr/bin/php8.0 /usr/local/bin/wp [COMMAND]
 ```
 
-The three available PHP versions, and their paths, are:
-* 7.4: `/usr/bin/php7.4`
+The two available PHP versions, and their paths, are:
 * 8.0: `/usr/bin/php8.0`
 * 8.1: `/usr/bin/php8.1`
 
@@ -100,7 +99,7 @@ To confirm which PHP version is used by WP-CLI, run:
 /usr/bin/php8.0 /usr/local/bin/wp cli info
 ```
 
-Confirm that the `PHP version` and `php.ini used` lines reference the 
+Confirm that the `PHP version` and `php.ini used` lines reference the
 expected version.
 
 
@@ -108,36 +107,8 @@ expected version.
 
 First, make sure you have php 8 installed ([see above in the FAQ](#if-your-configyml-does-not-include-the-desired-php-version-in-the-utilitiescore-section)).
 
-The steps to install are similar to the [existing docs](../docs/unit-tests.md). Until we switch completely to PHP8, I recommend making a parallel installation. PHP8 requires us to use PHPUnit 9, which requires us to use the WordPress 6 test suite and add the yoast/phpunit-polyfills  
+The steps to install are in the [unit testing docs](../docs/unit-tests.md). PHP8 requires us to use PHPUnit 9, which requires us to use the WordPress 6 test suite and add the yoast/phpunit-polyfills. They are very similar to how phpunit7 was installed, but you should still follow them from the beginning as you are installing new versions of phpunit and the wordpress test suite, as well as a new composer package.
 
 Any time you are using a specific version of php to run a command, you need the full path, i.e. `php8.0 /usr/local/bin/composer ...` instead of just `php8.0 composer ...`.
 
-
-```bash
-sudo mkdir -p /usr/share/php/phpunit9
-cd /usr/share/php/phpunit9
-sudo php8.0 /usr/local/bin/composer require --dev phpunit/phpunit ^9 --update-with-all-dependencies
-sudo ln -sf /usr/share/php/phpunit9/vendor/bin/phpunit /usr/bin/phpunit9
-cd
-git clone --depth 1 --branch 6.0.1 git@github.com:WordPress/wordpress-develop.git  wordpress-6
-cp -r wordpress-6/tests /srv/www/variety-com/public_html/  
-```
-
-Change into the pmc-plugins/pmc-unit-test directory of the site you're migrating.
-```bash
-cd pmc-plugins/pmc-unit-test
-php8.0 /usr/local/bin/composer require --dev yoast/phpunit-polyfills
-```
-
-You will need to export the PMC_PHPUNIT_BOOTSTRAP and the WP_TESTS_DIR. 
-
-Change into the pmc-plugins directory and run tests by passing the necessary configuration file. For instance, if you wanted to run the tests for pmc-global-functions: 
-```bash
-cd ../pmc-plugins
-php8.0  /usr/bin/phpunit9 --configuration=pmc-global-functions
-```
-Don't forget the php8.0 executable and the full path to phpunit9. 
-
-You will be prompted to migrate the phpunit.xml, but hold off until we've migrated everything to php8 environments.
-
-You will likely run into many new Fatal Errors that need fixing before you're able to successfully run a test until we have merged in a bunch of phpunit tests in pmc-plugins.
+You can keep your existing theme wp-tests-config.php, but you will need to add a new constant: `define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', '/home/vagrant/vendor/yoast/phpunit-polyfills/');`

--- a/docs/test-exports.md
+++ b/docs/test-exports.md
@@ -1,0 +1,175 @@
+# Exports for test configs
+
+## artnews
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/artnews-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/artnews-com/public_html/tests/phpunit
+```
+
+## bgr
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/bgr-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/bgr-com/public_html/tests/phpunit
+```
+
+## billboard
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/billboard-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/billboard-com/public_html/tests/phpunit
+```
+
+## blogher
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/blogher-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/blogher-com/public_html/tests/phpunit
+```
+
+## deadline
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/deadline-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/deadline-com/public_html/tests/phpunit
+```
+
+## dirt
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/dirt-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/dirt-com/public_html/tests/phpunit
+```
+
+## pmc-engineering
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/pmc-engineering-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/pmc-engineering-com/public_html/tests/phpunit
+```
+
+## events-fairchildlive
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/events-fairchildlive-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/events-fairchildlive-com/public_html/tests/phpunit
+```
+
+## footwearnews
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/footwearnews-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/footwearnews-com/public_html/tests/phpunit
+```
+
+## goldderby
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/goldderby-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/goldderby-com/public_html/tests/phpunit
+```
+
+## hollywoodreporter
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/hollywoodreporter-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/hollywoodreporter-com/public_html/tests/phpunit
+```
+
+## indiewire
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/indiewire-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/indiewire-com/public_html/tests/phpunit
+```
+
+## nova
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/nova/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/nova/public_html/tests/phpunit
+```
+
+## pmc
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/pmc-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/pmc-com/public_html/tests/phpunit
+```
+
+## robbreport
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/robbreport-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/robbreport-com/public_html/tests/phpunit
+```
+
+## rollingstone
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/rollingstone-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/rollingstone-com/public_html/tests/phpunit
+```
+
+## rr1
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/rr1-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/rr1-com/public_html/tests/phpunit
+```
+
+## sales-pmcdev-io
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/sales-pmcdev-io/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/sales-pmcdev-io/public_html/tests/phpunit
+```
+
+## sheknows
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/sheknows-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/sheknows-com/public_html/tests/phpunit
+```
+
+## soaps
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/soaps-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/soaps-com/public_html/tests/phpunit
+```
+
+## sportico
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/sportico-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/sportico-com/public_html/tests/phpunit
+```
+
+## sourcingjournal
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/sourcingjournal-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/sourcingjournal-com/public_html/tests/phpunit
+```
+
+## spy
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/spy-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/spy-com/public_html/tests/phpunit
+```
+
+## stylecaster
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/stylecaster-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/stylecaster-com/public_html/tests/phpunit
+```
+
+## tvline
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/tvline-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/tvline-com/public_html/tests/phpunit
+```
+
+## variety
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/variety-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/variety-com/public_html/tests/phpunit
+```
+
+## vibe
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/vibe-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/vibe-com/public_html/tests/phpunit
+```
+
+## wwd
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/wwd-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/wwd-com/public_html/tests/phpunit
+```
+
+## studios-wwd
+```
+export PMC_PHPUNIT_BOOTSTRAP=/srv/www/studios-wwd-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+export WP_TESTS_DIR=/srv/www/studios-wwd-com/public_html/tests/phpunit
+```

--- a/docs/unit-tests.md
+++ b/docs/unit-tests.md
@@ -4,6 +4,8 @@ For each site you provision, e.g. Sportico, you may run the theme and pmc-plugin
 
 NOTE, Ideally, we could provision wordpress-trunk into VVV via [custom-site-template-develop](https://github.com/Varying-Vagrant-Vagrants/custom-site-template-develop) (by setting skip_provisioning: false in config.yml) as it provides phpunit, test database, and the wp test suite. However, it forces you to use the latest (unreleased) version. Using its master branch can/has lead to issues when running tests with our pmc-unit-test bootstrap.php. Due to this, we setup the test environment manually (steps 1-3 below).
 
+NOTE the Second. If you're using php8 and phpunit9, you can install a parallel phpunit9 installation. Please [see the faq](../docs/faq.md#phpunit-with-php-8).
+
 1. Install phpunit
     ```bash
     # If not in VM...

--- a/docs/unit-tests.md
+++ b/docs/unit-tests.md
@@ -4,7 +4,6 @@ For each site you provision, e.g. Sportico, you may run the theme and pmc-plugin
 
 NOTE, Ideally, we could provision wordpress-trunk into VVV via [custom-site-template-develop](https://github.com/Varying-Vagrant-Vagrants/custom-site-template-develop) (by setting skip_provisioning: false in config.yml) as it provides phpunit, test database, and the wp test suite. However, it forces you to use the latest (unreleased) version. Using its master branch can/has lead to issues when running tests with our pmc-unit-test bootstrap.php. Due to this, we setup the test environment manually (steps 1-3 below).
 
-NOTE the Second. If you're using php8 and phpunit9, you can install a parallel phpunit9 installation. Please [see the faq](../docs/faq.md#phpunit-with-php-8).
 
 1. Install phpunit
     ```bash
@@ -15,30 +14,33 @@ NOTE the Second. If you're using php8 and phpunit9, you can install a parallel p
     ```bash
     $ sudo mkdir -p /usr/share/php/phpunit
     $ cd /usr/share/php/phpunit
-    $ sudo composer require --dev phpunit/phpunit ^7 --update-with-all-dependencies
+    $ sudo composer require --dev phpunit/phpunit ^9 --update-with-all-dependencies
     $ sudo ln -sf /usr/share/php/phpunit/vendor/bin/phpunit /usr/bin/phpunit
     ```
-1. Get the WP Test Suite
+1. Get the WP Test Suite and copy it into each provisioned site
     ```bash
     # If not in VM...
     $ vagrant ssh
     ```
    In VM...
     ```bash
-    # As of Sept 2021 pmc-unit-test is compatible with WP 5.8
-    # This is due to https://core.trac.wordpress.org/changeset/51559, as pmc-unit-test is not yet compatible with yoast/phpunit-polyfills
-    $ cd ~/
-    $ git clone --depth 1 --branch 5.8.1 git@github.com:WordPress/wordpress-develop.git
-    ```
-1. Copy the WP Test Suite per site
-    ```bash
-    # If not in VM...
-    $ vagrant ssh
-    ```
-   In VM...
-    ```bash
+    # As of Nov 2022 pmc-unit-test is compatible with WP 6.1
+    $ cd ~
+    $ git clone --depth 1 git@github.com:WordPress/wordpress-develop.git
     $ cp -r ~/wordpress-develop/tests/ /srv/www/sportico-com/public_html/
     ```
+1. Install yoasts/phpunit-polyfills. We'll install it in the home directory because we'll use an alternative loading approach.
+    ```bash
+    # If not in VM...
+    $ vagrant ssh
+    ```
+   In VM...
+    ```bash
+    $ cd ~
+    $ composer require --dev yoast/phpunit-polyfills
+    ```
+
+
 1. Create `wp-tests-config.php` per site
     ```bash
     # If not in VM...
@@ -50,7 +52,7 @@ NOTE the Second. If you're using php8 and phpunit9, you can install a parallel p
     ```
     1. open the file you copied `wp-tests-config.php` in your editor / IDE of choice.
     1. change line 4 to `define( 'ABSPATH', dirname( __FILE__ ) . '/' );`
-    1. Configure `DB_*` named constants: NOTE the DB_NAME should match your 
+    1. Configure `DB_*` named constants: NOTE the DB_NAME should match your
        provisioned site (see wp-config.php)
         ```
         define( 'DB_NAME', 'sportico-com' );
@@ -58,27 +60,28 @@ NOTE the Second. If you're using php8 and phpunit9, you can install a parallel p
         define( 'DB_PASSWORD', 'wp' );
         define( 'DB_HOST', 'localhost' );
         ```
-    1. Add the following constants
+    1. Add the following constants:
         ```
         define( 'PMC_IS_VIP_GO_SITE', true );
         define( 'VIP_GO_APP_ENVIRONMENT', 'development' );
+        define('WP_TESTS_PHPUNIT_POLYFILLS_PATH', '/home/vagrant/vendor/yoast/phpunit-polyfills/');
         ```
 1. Run tests
     1. Note, we must tell PHPUnit where our test bootstraps are located. Note, this must be done each time you SSH into vagrant (See below PHPStorm docs to automate this). Note, change `sportico-com` to the site you're testing within.
-    1. Note, if xdebug is enabled your tests will run VERY slowly. See 
+    1. Note, if xdebug is enabled your tests will run VERY slowly. See
        [xDebug documentation](https://varyingvagrantvagrants.org/docs/en-US/references/xdebug/ ). Only enable xdebug while testing if you wish to step-through debug your tests or generate a code coverage report.
-
+    1. Note, if you only want code coverage, try enabling pcov instead of xdebug `switch_php_debugmod pcov`. pcov seems to require less memory than xdebug.
 
     ```bash
     # If not in VM...
     $ vagrant ssh
     ```
-    
+
     In VM...
     ```bash
     You can add these variables to your bash, but make sure they are at the bottom of ~/.bash_profile as not to conflict with vvv's settings.
-    $ export PMC_PHPUNIT_BOOTSTRAP=/srv/www/sportico-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
-    $ export WP_TESTS_DIR=/srv/www/sportico-com/public_html/tests/phpunit
+    export PMC_PHPUNIT_BOOTSTRAP=/srv/www/artnews-com/public_html/wp-content/plugins/pmc-plugins/pmc-unit-test/bootstrap.php
+    export WP_TESTS_DIR=/srv/www/artnews-com/public_html/tests/phpunit
 
     # If you edited ~/.bash_profile reload it.
     $ source ~/.bash_profile
@@ -90,6 +93,14 @@ NOTE the Second. If you're using php8 and phpunit9, you can install a parallel p
     $ phpunit
     ```
 
+You can copy all the PMC_PHPUNIT_BOOTSTRAP and WP_TESTS_DIR settings into your local [from here](../docs/test-exports.md)
+
 To run tests in PHPStorm and/or Step-Through debug tests, see here: https://confluence.pmcdev.io/x/sIyzB (this replaces steps 4-7 above)
 
 ![Testing in PHPStorm](./Testing-in-PHPStorm.png)
+
+
+```
+
+
+```

--- a/generate-config.js
+++ b/generate-config.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const YAML = require("yaml");
 
 const configFileName = "config.yml";
-const defaultPhpVersion = 7.4;
+const defaultPhpVersion = 8.0;
 
 console.info(`Generating ${configFileName}...`);
 
@@ -17,9 +17,8 @@ const vvvConfig = {
       "memcached-admin",
       "opcache-status",
       "webgrind",
-      "php73",
-      "php74",
       "php80",
+      "php81",
     ],
     pmc: [
       "coretech",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -46,9 +46,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
       "dev": true
     }
   }

--- a/sites.json
+++ b/sites.json
@@ -67,8 +67,7 @@
   },
   "nova": {
     "site_title_prefix": "Nova",
-    "theme_repo": "git@github.com:penske-media-corp/pmc-nova-theme.git",
-    "php_version": 8.0
+    "theme_repo": "git@github.com:penske-media-corp/pmc-nova-theme.git"
   },
   "pmc.com": {
     "site_title_prefix": "PMC Corp",
@@ -85,12 +84,6 @@
     "parent_theme_slug": "pmc-core-v2"
   },
   "rollingstone.com": {
-    "site_title_prefix": "Rolling Stone",
-    "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-rollingstone-2018.git",
-    "parent_theme_slug": "pmc-core-v2",
-    "theme_dir_uses_vip": true
-  },
-  "rollingstone-2022.com": {
     "site_title_prefix": "Rolling Stone",
     "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-rollingstone-2022.git",
     "parent_theme_slug": "pmc-core-v2",
@@ -127,24 +120,11 @@
   },
   "sourcingjournal.com": {
     "site_title_prefix": "Sourcing Journal",
-    "provisioner_url": "git@github.com:Varying-Vagrant-Vagrants/custom-site-template.git",
-    "provisioner_branch": "master",
-    "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-sourcingjournal-2018.git",
-    "parent_theme_slug": "pmc-core-v2",
-    "theme_dir_uses_vip": true,
-    "php_version": 7.3
-  },
-  "sourcingjournal-2021.com": {
-    "site_title_prefix": "Sourcing Journal",
     "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-sourcingjournal-2021.git",
     "parent_theme_slug": "pmc-core-v2",
     "theme_dir_uses_vip": true
   },
   "spy.com": {
-    "site_title_prefix": "Spy",
-    "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-spy.git"
-  },
-  "spy-2022.com": {
     "site_title_prefix": "Spy",
     "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-spy-2022.git",
     "parent_theme_slug": "pmc-core-v2",
@@ -171,10 +151,6 @@
   },
   "wwd.com": {
     "site_title_prefix": "WWD",
-    "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-wwd-2016.git"
-  },
-  "wwd-2021.com": {
-    "site_title_prefix": "WWD 2021",
     "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-wwd-2021.git",
     "parent_theme_slug": "pmc-core-v2",
     "theme_dir_uses_vip": true

--- a/sites.json
+++ b/sites.json
@@ -1,7 +1,7 @@
 {
   "artnews.com": {
     "site_title_prefix": "Artnews",
-    "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-artnews-2019.git",
+    "theme_repo": "git@github.com:penske-media-corp/pmc-artnews-2019.git",
     "parent_theme_slug": "pmc-core-v2",
     "theme_dir_uses_vip": true
   },
@@ -40,12 +40,12 @@
   },
   "events.fairchildlive.com": {
     "site_title_prefix": "Fairchild Live Events",
-    "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-summits-wwd.git",
+    "theme_repo": "git@github.com:penske-media-corp/pmc-summits-wwd.git",
     "parent_theme_slug": "pmc-summits"
   },
   "footwearnews.com": {
     "site_title_prefix": "Footwearnews",
-    "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-footwearnews-2018.git",
+    "theme_repo": "git@github.com:penske-media-corp/pmc-footwearnews-2018.git",
     "parent_theme_slug": "pmc-core-v2"
   },
   "goldderby.com": {
@@ -114,7 +114,7 @@
   },
   "sportico.com": {
     "site_title_prefix": "Sportico",
-    "theme_repo": "git@bitbucket.org:penskemediacorp/pmc-sportico-2020.git",
+    "theme_repo": "git@github.com:penske-media-corp/pmc-sportico-2020.git",
     "parent_theme_slug": "pmc-core-v2",
     "theme_dir_uses_vip": true
   },


### PR DESCRIPTION
Updating docs for php8:
   * how to install phpunit9
   * how to install wordpress test suite
   * how to install yoast phpunit polyfills

Updated sites.json and config.yml:
   * removed deprecated sites
   * returned standard site names to the new redesign repos
   * all sites at php8 as the default
   * some sites updated after migrating to github