### PR TITLE
PASE-2103 | Update provisioner WordPress versions to 6.5

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -12,7 +12,7 @@ sites:
       site_title: Art Forum (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-artforum-2023.git
         theme_slug: ""
@@ -31,7 +31,7 @@ sites:
       site_title: Art Guide (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-artguide-2023.git
         theme_slug: ""
@@ -50,7 +50,7 @@ sites:
       site_title: Artnews (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-artnews-2019.git
         theme_slug: ""
@@ -69,7 +69,7 @@ sites:
       site_title: BGR (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@bitbucket.org:penskemediacorp/bgr.git
         theme_slug: ""
@@ -88,7 +88,7 @@ sites:
       site_title: Billboard (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-billboard-2021.git
         theme_slug: ""
@@ -107,7 +107,7 @@ sites:
       site_title: BlogHer (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-blogher-2020.git
         theme_slug: ""
@@ -126,7 +126,7 @@ sites:
       site_title: Deadline (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-deadline-2019.git
         theme_slug: ""
@@ -145,7 +145,7 @@ sites:
       site_title: Dirt (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-dirt-2020.git
         theme_slug: ""
@@ -164,7 +164,7 @@ sites:
       site_title: PMC Engineering (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-engineering-2021.git
         theme_slug: ""
@@ -183,7 +183,7 @@ sites:
       site_title: Fairchild Live Events (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-summits-wwd.git
         theme_slug: ""
@@ -202,7 +202,7 @@ sites:
       site_title: Footwearnews (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-footwearnews-2023.git
         theme_slug: ""
@@ -221,7 +221,7 @@ sites:
       site_title: Gold Derby (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-goldderby.git
         theme_slug: ""
@@ -240,7 +240,7 @@ sites:
       site_title: Hollywoodreporter (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-hollywoodreporter-2021.git
         theme_slug: ""
@@ -259,7 +259,7 @@ sites:
       site_title: IndieWire (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-indiewire-2023.git
         theme_slug: ""
@@ -278,7 +278,7 @@ sites:
       site_title: Nova (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-nova-theme.git
         theme_slug: ""
@@ -297,7 +297,7 @@ sites:
       site_title: PMC Corp (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-corporate-2018.git
         theme_slug: ""
@@ -316,7 +316,7 @@ sites:
       site_title: Robb Report (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-robbreport-2017-v2.git
         theme_slug: ""
@@ -335,7 +335,7 @@ sites:
       site_title: Robb Report UK (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-robbreport-2017-v2.git
         theme_slug: ""
@@ -354,7 +354,7 @@ sites:
       site_title: Rolling Stone (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-rollingstone-2022.git
         theme_slug: ""
@@ -373,7 +373,7 @@ sites:
       site_title: RR1 (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-summits-rr1.git
         theme_slug: ""
@@ -392,7 +392,7 @@ sites:
       site_title: Sales Microsites (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-salesmicrosite.git
         theme_slug: ""
@@ -411,7 +411,7 @@ sites:
       site_title: Sheknows (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-sheknows-2020.git
         theme_slug: ""
@@ -430,7 +430,7 @@ sites:
       site_title: Soaps (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-soaps-2018.git
         theme_slug: ""
@@ -449,7 +449,7 @@ sites:
       site_title: Sportico (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-sportico-2020.git
         theme_slug: ""
@@ -468,7 +468,7 @@ sites:
       site_title: Sourcing Journal (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-sourcingjournal-2021.git
         theme_slug: ""
@@ -487,7 +487,7 @@ sites:
       site_title: Spy (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-spy-2022.git
         theme_slug: ""
@@ -506,7 +506,7 @@ sites:
       site_title: Stylecaster (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-stylecaster-2023.git
         theme_slug: ""
@@ -525,7 +525,7 @@ sites:
       site_title: Flow Space (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-flow-2024.git
         theme_slug: ""
@@ -544,7 +544,7 @@ sites:
       site_title: TV Line (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-tvline-2023.git
         theme_slug: ""
@@ -563,7 +563,7 @@ sites:
       site_title: Ultimate Gift Guide (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-rr-giftguide-2023.git
         theme_slug: ""
@@ -582,7 +582,7 @@ sites:
       site_title: Variety (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-variety-2020.git
         theme_slug: ""
@@ -601,7 +601,7 @@ sites:
       site_title: Vibe (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-vibe-2021.git
         theme_slug: ""
@@ -620,7 +620,7 @@ sites:
       site_title: WWD (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-wwd-2021.git
         theme_slug: ""
@@ -639,7 +639,7 @@ sites:
       site_title: WWD Studios (LOCAL)
       admin_user: pmcdev
       admin_password: pmcdev
-      wp_version: 6.4
+      wp_version: 6.5
       pmc:
         theme_repo: git@github.com:penske-media-corp/pmc-wwd-studios-2017.git
         theme_slug: ""


### PR DESCRIPTION
For [PASE-2103](https://penskemedia.atlassian.net/browse/PASE-2103)

Updates sites configured for WordPress 6.4 to WordPress 6.5